### PR TITLE
Fix team page fetch failure log

### DIFF
--- a/modules/team.py
+++ b/modules/team.py
@@ -24,7 +24,7 @@ class Team:
         response_text = safe_request(url, category="rosters")
 
         if not response_text:
-            print(f"❌ Failed to fetch page for {selfame}")
+            print(f"❌ Failed to fetch page for {self.name}")
             return
 
         soup = BeautifulSoup(response_text, "html.parser")


### PR DESCRIPTION
## Summary
- correct typo in Team fetch failure message

## Testing
- `python -m py_compile modules/team.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841aaedb948832598a5325490ace20d