### PR TITLE
Fix variable name in all_active_players

### DIFF
--- a/modules/fetch.py
+++ b/modules/fetch.py
@@ -77,4 +77,4 @@ def get_all_active_players(season):
     "timestamp": time.time()
 }
     save_cache(cache)
-    return [Player(name, team, year) for name, team in cache["all_players"]["data"]]
+    return [Player(name, team, season) for name, team in cache["all_players"]["data"]]


### PR DESCRIPTION
## Summary
- fix Player object initialization to use `season`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841aaf9a1188325b2b5da1a1154aa37